### PR TITLE
switch back to grpc from grpc-js

### DIFF
--- a/modules/audiocodes.js
+++ b/modules/audiocodes.js
@@ -92,7 +92,7 @@ async function serverMessage(data, isBinary, ws, ws_state, asr) {
 
     if (!isBinary) {  // non-binary data will be string start/stop control messages
         ws_state = await  audioCodesControlMessage(data, asr, ws);
-        console.log("ws_socket->state : " + ws_state);
+        //console.log("ws_socket->state : " + ws_state);
         return ws_state;
     } else {
         if(ws_state == stateOf.STARTED) {
@@ -117,7 +117,7 @@ function wsServerConnection(ws, req) {
     let ws_state = stateOf.UNDEFINED;
     let asr = new RivaASRClient();
 
-    console.log('Client connected from %s', ip);
+    //console.log('Client connected from %s', ip);
 
     ws.on('message', async function serverMessage_cl(data, isBinary) {
         ws_state = await serverMessage(data, isBinary, ws, ws_state, asr);
@@ -128,7 +128,8 @@ function wsServerConnection(ws, req) {
         console.log(data);
     });
     ws.on('close', function close() {
-        console.log("closing connection for %s", ip);
+        //console.log("closing connection for %s", ip);
+        asr.end();
         ws.close();
     });
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "dotenv": "^16.0.0",
     "express": "^4.17.3",
     "google-protobuf": "^3.19.4",
+    "grpc": "^1.24.11",
     "regenerator-runtime": "^0.13.9",
     "wavefile": "^11.0.0",
     "ws": "^8.5.0",

--- a/riva_client/asr.js
+++ b/riva_client/asr.js
@@ -4,7 +4,8 @@
  */
 
 require('dotenv').config({ path: 'env.txt' });
-var grpc = require('@grpc/grpc-js');
+//var grpc = require('@grpc/grpc-js');
+var grpc = require('grpc');
 var protoLoader = require('@grpc/proto-loader');
 const { request } = require('express');
 
@@ -81,7 +82,7 @@ class RivaASRClient {
                 });
             })
             .on('error', (error) => {
-                console.log('Error via streamingRecognize callback');
+                console.log('Error via streamingRecognize callback' + error);
                 transcription_cb({
                     error: error
                 });
@@ -91,6 +92,9 @@ class RivaASRClient {
             });
 
         this.recognizeStream.write(this.firstRequest);
+    }
+    end() {
+        this.recognizeStream.end();
     }
 }
 

--- a/riva_client/testing_server.js
+++ b/riva_client/testing_server.js
@@ -55,7 +55,11 @@ function StreamingRecognize(call){
             call.write(final_msg);
         }
     });
+    call.on('error', function(err) {
+        console.log(err);
+    });
     call.on('end', function() {
+        call.end();
         console.log("request ended for :");
     });
 


### PR DESCRIPTION
grpc-js seems to have issues at  around 90-100 simultaneous streams on (AMD Ryzen Threadripper 3960X 24-Core Processor)  system - seeing errors like :
8 RESOURCE_EXHAUSTED: Bandwidth exhausted or memory limit exceeded
13 INTERNAL: Received RST_STREAM with code 2 (Internal server error)

This change reverts to the grpc package (even tho deprecated) and was tested to 512 streams with no observed errors.