### PR TITLE
[Node EOL] Upgrade to Node 24 LTS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,6 @@ workflows:
           # This is the node version to use for the `cimg/node` tag
           # Relevant tags can be found on the CircleCI Developer Hub
           # https://circleci.com/developer/images/image/cimg/node
-          version: '16.10'
+          version: '24.0'
           # If you are using yarn, change the line below from "npm" to "yarn"
           pkg-manager: npm

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM node:16
-RUN npm install -g npm@8.5.5
+FROM us-docker.pkg.dev/abridge-artifact-registry/cgr/abridge.com/chainguard-private/node-fips:24@sha256:2ce422dd44b26b25d0dcca2cf9e3c06b6ded78517d5fea7be5ff4a81aa0df54e
 WORKDIR /opt/riva/websocket-bridge
 COPY package*.json ./
 RUN npm ci --only=production


### PR DESCRIPTION
## Summary
Migrates this NVIDIA Riva websocket bridge from Node 16 to Node 24 LTS to address EOL findings from Semgrep supply-chain rules (SEC-382). This is the **largest jump in the batch** (16 -> 24), so the full step-3 breaking-change audit from the `node-24-upgrade` skill applies.

## Findings addressed
- `Dockerfile:1` — `abridge.supply-chain.dockerfile-node16-eol` (high)

## Changes
- `Dockerfile`: base image `node:16` -> Chainguard FIPS `node-fips:24` (pinned by digest per security standard). Dropped the `npm install -g npm@8.5.5` pin — Node 24 ships npm 11, and the old pin would be a downgrade.
- `.circleci/config.yml`: `node/test` orb `version: '16.10'` -> `'24.0'`. Orb kept at `circleci/node@4.7` (already supports `cimg/node:24.0`).
- `package.json`: no `engines.node` field to update; left untouched.

## Breaking-change audit (per node-24-upgrade skill)
Scope: `server.js`, `modules/`, `tests/`, `riva_client/`.

**Node 16 -> 18 cliff (most disruptive hurdle for this repo):**
- `createHash('md4')` / `--openssl-legacy-provider` / legacy ciphers (`des-ede3-cbc`, `rc2`, `bf-cbc`, `rc4`, `ripemd160`, `md4`): **no hits** in source or Dockerfile.
- Embedded cert strength: `certificates/cert.pem` is **4096-bit RSA + SHA256** (regenerated fresh via `make_certs.sh` with `rsa:4096`). Safely above OpenSSL 3.5 level 2's 2048-bit RSA minimum.
- `node-fetch` / `abort-controller` as direct deps: not present — no polyfill removal needed.
- HTTP `headersTimeout` / `requestTimeout` overrides: none. The server uses `https.createServer(...).listen()` with no timeout tuning, so it'll pick up the Node 18+ defaults (60s headers / 300s request). Websocket upgrade requests complete quickly so this should be fine; slow-ASR long-lived connections happen **after** the WS upgrade via `ws` library, not the HTTP server, so they're unaffected.
- `server.address().family` (string -> integer): no references.

**Node 18 -> 20:**
- `new WASI(...)`, `autoSelectFamily`, `process.exit` with non-number: no hits.

**Node 20 -> 22:**
- `require('punycode')`, `require('sys')`, `--loader`, `crypto.createCipher`: no hits.
- `fs.read` / `fs.readSync` without buffer: no hits.

**Node 23 / 24 removals:**
- `dirent.path`, `fs.F_OK` direct, `process.assert`, `url.parse`, `util.isX`, `util._extend`, `util.log`, `zlib.bytesRead`: no hits.

**Native addons / deps worth flagging for reviewers (not blocking this diff):**
- `grpc@^1.24.11` — the legacy native-addon gRPC package; **deprecated upstream for years** and almost certainly won't have prebuilt binaries for Node 24's NODE_MODULE_VERSION 137. `@grpc/grpc-js@^1.7.1` is already a dep and is the modern pure-JS replacement. Recommend removing `grpc` in a follow-up; a quick grep shows no `require('grpc')` in `server.js` / `modules/` / `riva_client/` so it may already be dead.
- `jest@^28.1.3` — skill recommends Jest v29+ for Node 22 and v30 for Node 24. Existing tests may throw `jest-environment-node` errors; flag for a follow-up bump.
- `bluebird` / `regenerator-runtime` — ES5-era polyfills; likely no-ops on Node 24 but not required.

## Tests added
None — no behavioral changes beyond version refs.

## How this was tested
- `npm ci` — skipped locally (audit workstation; gRPC native addon install is finicky).
- `npm test` (Jest 28) — CircleCI will validate on `cimg/node:24.0`. Expect potential fallout from Jest 28 on Node 24; see flagged follow-up above.
- Docker build — skipped locally; Chainguard FIPS image not pullable from this workstation.

## Reviewers
- @abridgeai/platform-engineering — as code owner
- @abridgeai/product-security — security review (Node EOL work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)